### PR TITLE
Update MegaPoker's Mainnet Address 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Optimized Smart Contract to Poke (`poke`).
 
 For Now, Hard Coded Addresses and Sequences. Easy for TechOps to Run.
 
-MegaPoker current Mainnet Address: [0x09e83eCBd4882959ed49A6f567B77a1E9A2ed9E2](https://etherscan.io/address/0x09e83eCBd4882959ed49A6f567B77a1E9A2ed9E2#code)
-> **_TODO:_** Deploy the new MegaPoker contract and update its Mainnet Address.
+MegaPoker current Mainnet Address: [0x727D37B7E185f4d57aEbb66a5e5CBd946Fa87999](https://etherscan.io/address/0x727D37B7E185f4d57aEbb66a5e5CBd946Fa87999#code)
 
 # OmegaPoker
 


### PR DESCRIPTION
Updates the `README.MD` file with the new MegaPoker [contract address](https://etherscan.io/address/0x727D37B7E185f4d57aEbb66a5e5CBd946Fa87999#code), deployed from the current `master` branch.